### PR TITLE
Add rgbds-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Fragments of code, effects, proof of concepts and generally non complete games.
 - [rgbds_textmate](https://github.com/Bananattack/rgbds_textmate) - Some syntax highlighting rules for coding in Z80 assembly as a Textmate language plugin. Works in Sublime Text 2 and 3\. The syntax is particularly designed for RGBDS and Game Boy-specific Z80 instructions.
 - [Z80 Assembly support for Visual Studio Code](https://github.com/Imanolea/z80asm-vscode)
 - [rgbds-vscode](https://github.com/DonaldHays/rgbds-vscode) - Visual Studio Code language extension for RGBDS GBZ80 Assembly
+- [rgbds-mode](https://github.com/japanoise/rgbds-mode) - Emacs major mode for RGBDS assembly.
 
 ### C
 


### PR DESCRIPTION
An Emacs major-mode (syntax highlighter and related boilerplate) for editing RGBDS assembly source.