### PR TITLE
Add lmmendes/game-boy-opcodes to Cheatsheets, Tables section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You can find a (way cooler) web version of this list [here](https://gbdev.github
 - [Opcode table](http://goldencrystal.free.fr/GBZ80Opcodes.pdf)
 - [Opcode table with timings and flags](http://www.devrs.com/gb/files/opcodes.html)
 - [Game Boy CPU Instruction Set Sheet (GCISheet)](http://www.devrs.com/gb/files/GBCPU_Instr.html) - Cheatsheet for the available Instruction Set.
+- [Game Boy Opcodes timings and flags in JSON](https://github.com/lmmendes/game-boy-opcodes/blob/master/opcodes.json) - JSON version of the pastraiser.com table ([repository](https://github.com/lmmendes/game-boy-opcodes))
 
 ### Game Boy Color
 

--- a/README.md
+++ b/README.md
@@ -97,12 +97,11 @@ You can find a (way cooler) web version of this list [here](https://gbdev.github
 #### Cheatsheets, Tables
 
 - [Game Boy Crib Sheet](https://github.com/JustinLloyd/Gameboy-Cribsheet/raw/master/Current%20Release/Gameboy%20Crib%20Sheet%20990823-0325.pdf) - A handy printable reference sheet with ASM opcodes, memory locations, and much more ([repository](https://github.com/JustinLloyd/Gameboy-Cribsheet)).
-- [OP Codes cheatsheet](http://pastraiser.com/cpu/gameboy/gameboy_opcodes.html)
+- [OP Codes cheatsheet](http://pastraiser.com/cpu/gameboy/gameboy_opcodes.html) - Gameboy CPU (LR35902) instruction set (a [JSON](https://github.com/lmmendes/game-boy-opcodes/blob/master/opcodes.json) version)
 - [rednex gbz80 opcode reference](https://rednex.github.io/rgbds/gbz80.7.html)
 - [Opcode table](http://goldencrystal.free.fr/GBZ80Opcodes.pdf)
 - [Opcode table with timings and flags](http://www.devrs.com/gb/files/opcodes.html)
 - [Game Boy CPU Instruction Set Sheet (GCISheet)](http://www.devrs.com/gb/files/GBCPU_Instr.html) - Cheatsheet for the available Instruction Set.
-- [Game Boy Opcodes timings and flags in JSON](https://github.com/lmmendes/game-boy-opcodes/blob/master/opcodes.json) - JSON version of the pastraiser.com table ([repository](https://github.com/lmmendes/game-boy-opcodes))
 
 ### Game Boy Color
 


### PR DESCRIPTION
Adding lmmendes/game-boy-opcodes to Cheatsheets, Tables section.

It's basically a JSON representation of the http://www.pastraiser.com/cpu/gameboy/gameboy_opcodes.html for ease of parsing.

The file also includes some opcode length and timing fixes for known issues with the pastraiser.com original content.