### PR TITLE
Remove OAM DMA tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,6 @@ Fragments of code, effects, proof of concepts and generally non complete games.
 
 #### Timings
 
-- [Game Boy DMA transfer routines](http://exez.in/gameboy-dma) - Understanding and using DMA routines.
 - [Nitty Gritty Gameboy Cycle Timing](http://blog.kevtris.org/blogfiles/Nitty%20Gritty%20Gameboy%20VRAM%20Timing.txt)
 - [Mode3 Sprite Timing](https://www.reddit.com/r/EmuDev/comments/59pawp/gb_mode3_sprite_timing/)
 - [GameBoy Color DMA-Transfers v0.0.1](http://gameboy.mongenel.com/dmg/gbc_dma_transfers.txt)


### PR DESCRIPTION
This tutorial is filled with bad practice, and as such is not awesome.

The section in which it's placed was wrong, too.