### PR TITLE
Adding GingerBread and Game Boy Assembly Programming for the Modern Game Developer

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,10 @@ Guides, tutorials and tools to develop software for Game Boy using the developme
 - [GameBoy programming tutorial: Hello World!](http://peterwynroberts.com/?p=10) - Step by step tutorial.
 - [DMGreport](https://github.com/lancekindle/DMGreport) - Game programming tutorials in assembly.
 - [OAM DMA tutorial](https://exez.in/gameboy-dma) - Example of how to use OAM DMA in assembly.
+- [Game Boy Assembly Programming for the Modern Game Developer](https://teamlampoil.se/book/gbasmdev.pdf) - An e-book about making Game Boy games in Assembly.
+
+#### Software libraries
+- [GingerBread](https://github.com/ahrnbom/gingerbread) - A software library for making your own Game Boy games. It uses the e-book [Game Boy Assembly Programming for the Modern Game Developer](https://teamlampoil.se/book/gbasmdev.pdf) as its documentation.
 
 #### Sources
 

--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ See [LICENSE](LICENSE) for more information.
 
 ### Acknowledgements
 
-Thanks to [every](https://github.com/avivace/awesome-gbdev/graphs/contributors) contributor of this project, Jeff Frohwein, Pascal Felber, KOOPa, Pan of Anthrox, GABY, Marat Fayzullin, Paul Robson, BOWSER, neviksti, Martin “nocash" Korth, Nitro2k01, Duo, Chris Antonellis, Michael Hope, Beware, Jonathan “Lord Nightmare” Gevaryahu, Carsten Sorense, Sindre Aamås, Otaku No Zoku, GeeBee.
+Thanks to [every](https://github.com/avivace/awesome-gbdev/graphs/contributors) contributor of this project, Jeff Frohwein, Pascal Felber, KOOPa, Pan of Anthrox, GABY, Marat Fayzullin, Paul Robson, BOWSER, neviksti, Martin “nocash" Korth, Nitro2k01, Duo, Chris Antonellis, Michael Hope, Beware, Jonathan “Lord Nightmare” Gevaryahu, Carsten Sorense, Sindre Aamås, Otaku No Zoku, GeeBee, Martin Ahrnbom.
 
 ### Sponsors
 

--- a/README.md
+++ b/README.md
@@ -288,10 +288,7 @@ Guides, tutorials and tools to develop software for Game Boy using the developme
 - [GameBoy programming tutorial: Hello World!](http://peterwynroberts.com/?p=10) - Step by step tutorial.
 - [DMGreport](https://github.com/lancekindle/DMGreport) - Game programming tutorials in assembly.
 - [OAM DMA tutorial](https://exez.in/gameboy-dma) - Example of how to use OAM DMA in assembly.
-- [Game Boy Assembly Programming for the Modern Game Developer](https://teamlampoil.se/book/gbasmdev.pdf) - An e-book about making Game Boy games in Assembly.
-
-#### Software libraries
-- [GingerBread](https://github.com/ahrnbom/gingerbread) - A software library for making your own Game Boy games. It uses the e-book [Game Boy Assembly Programming for the Modern Game Developer](https://teamlampoil.se/book/gbasmdev.pdf) as its documentation.
+- [Game Boy Assembly Programming for the Modern Game Developer](https://github.com/ahrnbom/gbapfomgd) - An e-book about making Game Boy games in Assembly.
 
 #### Sources
 
@@ -308,13 +305,14 @@ Fragments of code, effects, proof of concepts and generally non complete games.
 - [STAT interrupt timings](http://gameboy.mongenel.com/dmg/istat98.txt)
 - [Video Timing](https://github.com/jdeblese/gbcpu/wiki/Video-Timing)
 
-#### Boilerplates
+#### Boilerplates and libraries
 
 - [gb-template](https://github.com/exezin/gb-template) - A template with basic functions such as joypad input, DMA transfers, and map/tile data loading.
 - [rgbds-template](https://github.com/nezticle/rgbds-template) - Basic hello-world example for Game Boy using RGBDS.
 - [Game Boy Assembly Language Primer](http://www.devrs.com/gb/files/galp.zip) - Simple template code with memory defines, copy routines and IBM font tilemap.
 - [bootstrap.gb](https://github.com/yenatch/bootstrap.gb) - An example Game Boy project.
 - [Gameboy Boilerplate](https://github.com/junebug12851/GameboyBoilerplateProj) - Boilerplate project to move quicker into the actual assembly code for your game.
+- [GingerBread](https://github.com/ahrnbom/gingerbread) - A software library for making your own Game Boy games. It is made to be used alongside the book [Game Boy Assembly Programming for the Modern Game Developer](https://github.com/ahrnbom/gbapfomgd) which also doubles as documentation.
 
 #### Syntax highlighting packages
 
@@ -502,7 +500,7 @@ See [LICENSE](LICENSE) for more information.
 
 ### Acknowledgements
 
-Thanks to [every](https://github.com/avivace/awesome-gbdev/graphs/contributors) contributor of this project, Jeff Frohwein, Pascal Felber, KOOPa, Pan of Anthrox, GABY, Marat Fayzullin, Paul Robson, BOWSER, neviksti, Martin “nocash" Korth, Nitro2k01, Duo, Chris Antonellis, Michael Hope, Beware, Jonathan “Lord Nightmare” Gevaryahu, Carsten Sorense, Sindre Aamås, Otaku No Zoku, GeeBee, Martin Ahrnbom.
+Thanks to [every](https://github.com/avivace/awesome-gbdev/graphs/contributors) contributor of this project, Jeff Frohwein, Pascal Felber, KOOPa, Pan of Anthrox, GABY, Marat Fayzullin, Paul Robson, BOWSER, neviksti, Martin “nocash" Korth, Nitro2k01, Duo, Chris Antonellis, Michael Hope, Beware, Jonathan “Lord Nightmare” Gevaryahu, Carsten Sorense, Sindre Aamås, Otaku No Zoku, GeeBee.
 
 ### Sponsors
 


### PR DESCRIPTION
Added GingerBread and the book _Game Boy Assembly Programming for the Modern Game Developer_ (both made by me). I added a new section for "Software libraries" as GingerBread didn't really fit "Sources" or "Boilerplates" in my opinion. If you/someone feels GingerBread should belong to some other category, feel free to change it (or let me know).