### PR TITLE
Add swotGB notes page to the emulator development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ You can find a (way cooler) web version of this list [here](https://gbdev.github
 - [Emulation Accuracy](https://github.com/Gekkio/mooneye-gb/blob/master/docs/accuracy.markdown)
 - [Decoding Gameboy Z80 opcodes](https://gb-archive.github.io/salvage/decoding_gbz80_opcodes/Decoding%20Gamboy%20Z80%20Opcodes.html) - How to algorithmically decode Game Boy instructions (as opposed to writing one huge switch-case statement).
 - [Porting a GO Game Boy emulator to WebAssembly](https://djhworld.github.io/post/2018/09/21/i-ported-my-gameboy-color-emulator-to-webassembly/)
+- [About swotGB](https://mitxela.com/projects/swotgb/about) - Notes about the development of a Game Boy emulator in Javascript.
 - [List of open source emulators](EMULATORS.md)
 
 ### Testing


### PR DESCRIPTION
I found this page which gives some insight into the development process of swotGB, a javascript Game Boy emulator. 
I thought it might be a good addition to awesome gbdev, as it provides nice details about the development process, some of its intricacies as well as the fun that comes with it.