### PR TITLE
add bootrom expected values dump blog post to Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ You can find a (way cooler) web version of this list [here](https://gbdev.github
 - [Mealybug Tearoom Tests](https://github.com/mattcurrie/mealybug-tearoom-tests)
 - [GB Accuracy Tests](http://tasvideos.org/EmulatorResources/GBAccuracyTests.html)
 - [144p Test Suite](https://github.com/pinobatch/240p-test-mini/tree/master/gameboy) - Port of Artemio Urbina's 240p Test Suite to the Game Boy.
+- [Bootrom Expected Values Dump Post](https://pa.blocanse.co/posts/gameboy-testing/) - Dump of expected CPU register values for the first ~12,000 cycles of the Game Boy bootrom sequence and how to use it for testing.
 
 ## Software Development
 


### PR DESCRIPTION
I wrote a blog post about a way to smoke-test and regression-test emulator cpu implementations, and was hoping to let the community know so new emulator developers could benefit.

 [Bootrom Expected Values Dump](https://pa.blocanse.co/posts/gameboy-testing/) - Dump of expected CPU register values for the first ~12,000 cycles of the Game Boy bootrom and how to make use of it.