### PR TITLE
fix broken RGBDS docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You can find a (way cooler) web version of this list [here](https://gbdev.github
 #### Opcodes
 
 - [gb-opcodes](https://gbdev.github.io/gb-opcodes/optables/) - Opcodes table
-- [RGBDS opcodes reference](https://rgbds.gbdev.io/docs/gbz80.7) - A reference of all instructions, including short descriptions, cycle and byte counts, and explanations of flag modifications.
+- [RGBDS opcodes reference](https://rgbds.gbdev.io/docs/v0.5.2/gbz80.7) - A reference of all instructions, including short descriptions, cycle and byte counts, and explanations of flag modifications.
 
 ### Game Boy Color
 


### PR DESCRIPTION
If you go to the [index page](https://rgbds.gbdev.io/docs/) it has multiple versions to choose from. I assume using the stable version here would make sense? Otherwise, I could change to master URL instead. 