### PR TITLE
Add link to fixed KiCad version of DMG-CPU B chip schematics

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You can find a (way cooler) web version of this list [here](https://gbdev.github
 - [ESP8266 GB Printer](https://github.com/applefreak/esp8266-gameboy-printer) - A device that emulates the GB Printer and lets you retrieve images using WiFi.
 - [fruttenboel](http://verhoeven272.nl/fruttenboel/Gameboy/index.html) - Page with loads of information on the hardware, custom boards to interface with the console and other related projects.
 - [Game Boy hardware database](https://gbhwdb.gekkio.fi/) - Data and photos of various types of Game Boy consoles.
-- [DMG-CPU-Inside](https://github.com/furrtek/DMG-CPU-Inside) - Schematics and annotated overlay for the DMG-CPU-B chip, extracted from die photos.
+- [dmg-schematics](https://github.com/msinger/dmg-schematics) - Schematics and annotated overlay for the DMG-CPU B chip, extracted from die photos, made with KiCad. Also contains Electric VLSI library with layouts for some of the cells and memories.
 
 ### Peripherals
 


### PR DESCRIPTION
Hi,

@rgalland and I, we independently simulated the living hell out of the schematics in [DMG-CPU-Inside](https://github.com/furrtek/DMG-CPU-Inside), hopefully catching all the bugs.
These are our simulations:
* https://github.com/rgalland/dmg_gb_ppu_simulation
* https://github.com/msinger/dmg-sim

We reported a lot of issues, but I think @furrtek is very busy de-capping some other chips, so we decided to remake the schematics in KiCad. :)

I removed the dash (-) between "CPU" and "B" in the other line, because the label on the chip always reads "DMG-CPU B", not "DMG-CPU-B". I thought since you take good care of spelling "Game Boy" the correct way, this should be corrected too.

We think our schematics are now mostly correct. There are still some swapped inputs of AND- and OR-gates, which are obviously not that important, we will fix over time.