### PR TITLE
Add Game Boy Doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ You can find a (way cooler) web version of this list [here](https://gbdev.github
 - [Porting a GO Game Boy emulator to WebAssembly](https://djhworld.github.io/post/2018/09/21/i-ported-my-gameboy-color-emulator-to-webassembly/)
 - [About swotGB](https://mitxela.com/projects/swotgb/about) - Notes about the development of a Game Boy emulator in JavaScript.
 - [List of open source emulators](EMULATORS.md)
+- [Game Boy Doctor](https://github.com/robert/gameboy-doctor) - A command line tool for comparing logs from your emulator to those from a known-correct one. Useful for line-by-line debugging of Blargg's test ROMs.
 
 ### Testing
 


### PR DESCRIPTION
https://github.com/robert/gameboy-doctor

Moved over from https://github.com/gbdev/gbdev.github.io/pull/65 !

cc @avivace 