### PR TITLE
Added opcode_count to Development Tools Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ The [Choosing tools for Game Boy development](https://gbdev.io/guides/tools.html
 - [Game Boy Text Tools](https://github.com/raphaklaus/gameboy-text-tools) - Set of tools for text manipulation and translation of Game Boy ROMs written in Node.js.
 - [evscript](https://github.com/eievui5/evscript) - A scripting language for the Game Boy, useful for enemy AI, dialogue, animations, and coroutines.
 - [evunit](https://github.com/eievui5/evunit) - A unit testing program for assembly code.
+- [opcode_count](https://github.com/rondnelson99/opcode_count) - Generates statistics on which CPU instructions are run the most often using Python and Emulicious
 
 #### Graphics utilities
 


### PR DESCRIPTION
This is a super-simple script I made the other day that can be used with Emulicious to generate statistics on which instructions get run the most by the CPU. TBH I'm not sure if it's really awesome enough for the list, since it's so basic and not really well-written at all. I guess I'll let the people here be the judge of that, but hopefully I at least set up the fork and PR properly.