### PR TITLE
Add link to Blender project containing GB CPU

### DIFF
--- a/EMULATORS.md
+++ b/EMULATORS.md
@@ -34,7 +34,7 @@
 | [weplay](https://github.com/rauchg/weplay) | JavaScript | Collaborative Game Boy emulation |
 | [GBRE](https://github.com/ericgramgb/GBRE) | JavaScript | GB Runtime Environment for iOS (iOS Safari and Chrome) |
 | [gameboy-Online](https://github.com/taisel/gameboy-Online) | JavaScript | Uses HTML5 canvas and JavaScript audio APIs |
-| [node-gameboy](https://github.com/nakardo/node-gameboy) | Node.js |
+| [node-gameboy](https://github.com/gb-archive/node-gameboy) | Node.js |
 | [php-terminal-Game Boy-emulator](https://github.com/gabrielrcouto/php-terminal-gameboy-emulator) | PHP | |
 | [PyBoy](https://github.com/Baekalfen/PyBoy) | Python | Mac, Linux and Windows |
 | [barnacleboy](https://github.com/rep-nop/barnacleboy) | Rust | |

--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ Methods to improve and/or manipulate the camera's quality and behavior:
 - [GBCartRead](https://github.com/insidegadgets/GBCartRead) - Read ROM, Read RAM or Write RAM from/to a GameBoy Cartridge.
 - [GBxCart-RW](https://github.com/insidegadgets/GBxCart-RW) - A device for reading game ROMs, save games and restoring saves for GB, GBC and GBA carts from your PC via USB.
 - [Dumping the Super Game Boy Boot ROM](http://www.its.caltech.edu/~costis/sgb_hack/)
+- [sm83-render](https://github.com/msinger/sm83-render) - A 3D model of the Game Boy CPU layout in Blender.
 
 ### Directories
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Guides, tutorials and tools to develop software for Game Boy using the developme
 
 ### ASM
 
-- **[gb asm tutorial](https://eldred.fr/gb-asm-tutorial)** - Step by step tutorial, building several ROMs to accompany its explanations.
+- **[gb asm tutorial](https://gbdev.io/gb-asm-tutorial)** - Step by step tutorial, building several ROMs to accompany its explanations.
 - [hardware.inc](https://github.com/tobiasvl/hardware.inc) - Standard include file containing Game Boy hardware definitions for use in RGBDS projects.
 - [Assembly tutorial by David Pello](https://gb-archive.github.io/salvage/tutorial_de_ensamblador/tutorial_de_ensamblador_la_decadence.html) - Good document to learn to produce working asm code for gb. Brief explanations of many important topics. Many examples with commented source code.
 - [assemblydigest](https://github.com/assemblydigest/gameboy) - Exploring Game Boy programming techniques:
@@ -338,7 +338,7 @@ Guides, tutorials and tools to develop software for Game Boy using the developme
 
 Fragments of code, effects, proof of concepts and generally non complete games.
 
-- [dev'rs ASM section](http://www.devrs.com/gb/asmcode.php) - A lot of working demos and sources.
+- [dev'rs ASM section](https://web.archive.org/web/20250329180046/http://www.devrs.com/gb/asmcode.php) - A lot of working demos and sources.
 - [EmmaEwert's experiments](https://github.com/EmmaEwert/gameboy) - A collection of prototype programs, mostly just toying around. Among others, a daylight effect, transparency and a weather effect.
 - [DeadCScroll](https://github.com/gb-archive/DeadCScroll) - A detailed tutorial on how to make the screen wobble, among other "raster effects"
 


### PR DESCRIPTION
Hi,
I thought some people might find it exciting to render the guts of the Game Boy CPU, so I created a repo with just the 90 MB Blender file in it. The layout from which I created the 3D model is in the dmg-schematics repository that is already linked at the bottom of the Hardware section.
I'm not sure if the Related Projects section is the right place to add the link, I didn't find any heading that describes it better.