### PR TITLE
Add link to visual-sm83 simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ Methods to improve and/or manipulate the camera's quality and behavior:
 - [GBxCart-RW](https://github.com/insidegadgets/GBxCart-RW) - A device for reading game ROMs, save games and restoring saves for GB, GBC and GBA carts from your PC via USB.
 - [Dumping the Super Game Boy Boot ROM](http://www.its.caltech.edu/~costis/sgb_hack/)
 - [sm83-render](https://github.com/msinger/sm83-render) - A 3D model of the Game Boy CPU layout in Blender.
+- [visual-sm83](https://iceboy.a-singer.de/visual6502/expert-sm83.html) - A visual transistor level simulation of the Game Boy CPU core in JavaScript, running in a browser.
 
 ### Directories
 


### PR DESCRIPTION
Hi again,
I managed to port the [visual6502.org](http://www.visual6502.org) simulator for the Game Boy CPU. I'm also not sure to what category it fits best, so I appended it to related projects again. Please let me know if you think it belongs somewhere else.

I made a pull-request to get the Game Boy CPU merged upstream, but there is no reaction yet: https://github.com/trebonian/visual6502/pull/71
I'm afraid the project is dead. If it gets merged at some day, I will make a pull-request here to change the link to the official visual6502.org site.