### PR TITLE
Add hash-bench-gb to Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ Complete and open source games.
 - [matrix-rain-gb](https://github.com/wtjones/matrix-rain-gb) - A Matrix digital rain effect in assembler.
 - [GBVideoPlayer](https://github.com/LIJI32/GBVideoPlayer) - A technical demo demonstrating how the Game Boy LCD controller can be hacked to make a Game Boy Color play a full motion video in color, together with music.
 - [GBVideoPlayer2](https://github.com/LIJI32/GBVideoPlayer2) - The second iteration of the above demo, which increases the resolution, adds *stereo- PCM audio, and introduces video compression*.
+- [hash-bench-gb](https://github.com/dmang-dev/hash-bench-gb) - Hash-algorithm benchmark cartridge that times 18 cryptographic and non-cryptographic hashes (CRC, MD5, SHA-1, etc.) on the SM83 and displays ms/iter and KB/s on screen.
 
 ## Reverse Engineering
 


### PR DESCRIPTION
## What this PR does

Adds a single entry to **Homebrews → Demos** (per the contribution guide's "add to bottom of relevant category"):

```markdown
- [hash-bench-gb](https://github.com/dmang-dev/hash-bench-gb) - Hash-algorithm benchmark cartridge that times 18 cryptographic and non-cryptographic hashes (CRC, MD5, SHA-1, etc.) on the SM83 and displays ms/iter and KB/s on screen.
```

## Why "Demos" rather than another section

`hash-bench-gb` sits naturally with the other non-game technical homebrew demonstrations already there — `matrix-rain-gb`, `GBVideoPlayer*`, `10 PRINT`, etc. It's not a game (so not Homebrews/C), not an emulator-accuracy test ROM (so not Emulator Development/Testing), and not a tutorial (so not Programming/C). I considered Programming/C but the project is positioned as a working benchmark, not as instructional material.

If a reviewer thinks it belongs elsewhere — Software Development → Tools, or Related projects, or even Programming → C as worked example — happy to move it.

## Project at a glance

- **Repo:** https://github.com/dmang-dev/hash-bench-gb
- **v1.0.0 release with prebuilt `.gb` + `.gbc` ROMs:** https://github.com/dmang-dev/hash-bench-gb/releases/tag/v1.0.0
- **License:** MIT
- **Built with:** GBDK-2020 / SDCC
- **Tested in:** mGBA, BGB, SameBoy

## Checklist (per [CONTRIBUTING.md](https://github.com/gbdev/awesome-gbdev/blob/master/CONTRIBUTING.md))

- [x] Resource is in English
- [x] Resource is in a minimal working state (prebuilt ROMs committed + downloadable from the v1.0.0 release)
- [x] Resource has a clear purpose (hash-algorithm performance benchmark on SM83)
- [x] Resource has documentation (README explains every algorithm, build, run, controls, why GB is limited to 18 algos)
- [x] Entry uses the required `[name](url) - Description.` format
- [x] Description starts with a capital letter and ends with a period
- [x] Entry added to the bottom of an existing section
- [x] Uses "Game Boy" rather than "gameboy" / "GameBoy" in the description

## Disclosure

I'm the author.
