### PR TITLE
Add Revenant (Rust/WASM GB/GBC emulator) to Open Source emulators

### DIFF
--- a/EMULATORS.md
+++ b/EMULATORS.md
@@ -41,6 +41,7 @@
 | [gb-rs](https://github.com/simias/gb-rs) | Rust | |
 | [scimitar](https://github.com/tompko/scimitar) | Rust | |
 | [rustboy](https://github.com/VelocityRa/rustboy) | Rust | A basic DMG emulator written in Rust, using the Piston engine for window creation and graphics |
+| [Revenant](https://github.com/zaiqltd/revenant) | Rust | Gate-accurate GB/GBC emulator compiled to WebAssembly. Live in-browser demo, CPU/PPU debugger, instruction rewind. dmg-acid2 pixel-perfect. |
 | [Gambattye](https://github.com/Ben10do/Gambattye) | Swift | macOS, powered by a fork of Gambatte |
 | [wasmBoy](https://github.com/torch2424/wasmBoy) | Web Assembly (AssemblyScript) | GB/GBC *Library* written for Web Assembly using AssemblyScript. Shell/Debugger in Preact.|
 | [vaporBoy](https://github.com/torch2424/vaporBoy) | Javascript | PWA. Powered by [wasmBoy](https://github.com/torch2424/wasmBoy) |


### PR DESCRIPTION
Adds Revenant, a from-scratch gate-accurate Game Boy / Game Boy Color emulator in Rust compiled to WebAssembly, with a live in-browser demo, a CPU/PPU debugger and instruction rewind. Renders dmg-acid2 pixel-perfect (0/23040 px off real hardware on DMG and CGB) and passes 130/279 of the canonical hardware test ROMs. Open source, working, scorecard in the repo. Live demo: https://zaiqltd.github.io/revenant/