### PR TITLE
Clarify the contributing guidelines for the main list versus MORE.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Search previous suggestions and open issues before making a new one, as yours ma
 
 Here's how you can contribute:
 
-- Look at open [Issues](https://github.com/avivace/awesome-gbdev/issues) and provide help or feedback 
+- Look at open [Issues](https://github.com/avivace/awesome-gbdev/issues) and provide help or feedback
 - [Add a resource](#adding-a-resource)
 - [Correct and improve existing entries](#correcting-and-improving-resources)
 - [Fix broken links and unavailable resources](#removing-unavailable-resources)
@@ -20,14 +20,16 @@ If you are unsure about something or need help, we have a friendly Discord [chat
 
 For a resource to be added to the list, it must...
 
-- Be in english;
+- Be in English;
 - Be in a minimal working state;
 - Have a clear purpose (implementation reference is okay, too) and/or provide something interesting;
-- Provide a minimal documentation briefly describing what is the project and how to make use of it.
+- Provide a minimal documentation briefly describing what is the project and how to make use of it;
+- Have reached a state where you would personally recommend it to the Game Boy community in general;
+- Be *awesome*.
 
-These criteria are discussed [here](https://github.com/gbdev/awesome-gbdev/issues/96).
+That last criterion is the most subjective one, but it's what distinguishes this list from being a raw collection of everything related to Game Boy development in general. Don't take the name too seriously -- not being on the list doesn't mean your project *isn't* awesome, and vice-versa, but we would rather leave things out than include too much.
 
-If the resource is in another language, still work in progress, abandoned or you don't think reaches the described standard BUT it's still related to Game Boy development/hacking you can add it to the **MORE.md** file.
+Historically there has been some tension between this list being a curated subset of "awesome" resources, and being a comprehensive set of all reasonable resources. For the latter, cases which don't *quite* make it to the main list, we have [**MORE.md**](MORE.md). If the resource is in a non-English language, still a work in progress, abandoned, or doesn't reach the described standard *but* is still related to Game Boy development/hacking, then you can add it to the **MORE.md** file.
 
 ### Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ For a resource to be added to the list, it must...
 
 That last criterion is the most subjective one, but it's what distinguishes this list from being a raw collection of everything related to Game Boy development in general. Don't take the name too seriously -- not being on the list doesn't mean your project *isn't* awesome, and vice-versa, but we would rather leave things out than include too much.
 
-Historically there has been some tension between this list being a curated subset of "awesome" resources, and being a comprehensive set of all reasonable resources. For the latter, cases which don't *quite* make it to the main list, we have [**MORE.md**](MORE.md). If the resource is in a non-English language, still a work in progress, abandoned, or doesn't reach the described standard *but* is still related to Game Boy development/hacking, then you can add it to the **MORE.md** file.
+For resources which don't *quite* make it to the main list, we have [**MORE.md**](MORE.md). If the resource is in a non-English language, still a work in progress, abandoned, or doesn't reach the described standard *but* is still related to Game Boy development/hacking, then you can add it to the **MORE.md** file.
 
 ### Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ For a resource to be added to the list, it must...
 - Have reached a state where you would personally recommend it to the Game Boy community in general;
 - Be *awesome*.
 
-That last criterion is the most subjective one, but it's what distinguishes this list from being a raw collection of everything related to Game Boy development in general. Don't take the name too seriously -- not being on the list doesn't mean your project *isn't* awesome, and vice-versa, but we would rather leave things out than include too much.
+That last criterion is the most subjective one and ultimately a matter of maintainer judgment.
 
 For resources which don't *quite* make it to the main list, we have [**MORE.md**](MORE.md). If the resource is in a non-English language, still a work in progress, abandoned, or doesn't reach the described standard *but* is still related to Game Boy development/hacking, then you can add it to the **MORE.md** file.
 


### PR DESCRIPTION
Fixes #262

Currently the guidelines link to issue #96 for "discussion" of the criteria for adding a resource to the "Awesome" list. I think this could be more helpful -- issue discussion is inherently premature, with potentially conflicting viewpoints being hashed out, and not being part of the actual document implies that it's not essential to read.

Meanwhile, the criteria actually listed in CONTRIBUTING.md don't quite clarify why a project wouldn't "deserve" to be on the Awesome List, despite meeting the (lenient) criteria we list. A "minimal working state", "minimal documentation", "something interesting" -- most people's projects already meet that qualification.

Of course, the issue #96 discussed this exact tension, between this list as a curated set of widely-useful resources, versus being "a raw list of everything related to Game Boy (Development) in general". If we want MORE.md to be for the latter, I think that should be stated explicitly, so I opened this PR to do it.

(As it currently stands, it sounds like MORE.md is for incomplete, buggy, abandoned work -- which as far as I know is *not* the intention. It's not a dumping grounds for work not even good enough to be on the main list. It's a place for work which fails *some* essential criterion of the main list, but makes up for it in other ways, e.g. a high-quality popular tutorial that happens not to be in English, or a half-finished demo that still shows off some unique trick.)

I borrowed some of the phrasing here from people discussion in that issue. Maybe more of it should be here. Before reading over its comments, I had inferred that the "awesome" list is for widely useful, technically interesting, historically relevant, or already popular links. Maybe those really are our general criteria, so we could spell them out here. But ISSOtm actually critiqued "historically important" in that issue: "From a preservation standpoint, yes; from a usability standpoint, not if it has been improved." So maybe we should explicitly state that historic but supserseded resources belong in MORE.md. (And review what's currently on the list since some of it maybe ought to be moved there by now.)