### PR TITLE
Fix links that CI complains about

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,6 @@ jobs:
         sudo dpkg -i brok-1.1.0_x86-64-linux.deb
 
     - name: Check for dead links
-      run: brok --only-failures *.md
+      # tcrf.net uses DDoS protection that breaks link checkers
+      # <https://blog.xkeeper.net/uncategorized/tcrf-has-been-getting-ddosed/>
+      run: brok --only-failures --ignore "https://tcrf.net" *.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,7 +40,7 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct/][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://www.contributor-covenant.org/
+[version]: https://www.contributor-covenant.org/version/1/4/code-of-conduct/

--- a/MORE.md
+++ b/MORE.md
@@ -1,9 +1,8 @@
 # More
 
-
 - [gameboy homebrew](https://github.com/ProudGecko/gameboy) - Gameboy Homebrew Development (David Schamber).
 - [How to make a (GameBoy) emulator?](https://github.com/gb-archive/salvage/blob/master/misc/Petar-V-emulation.pdf) by Petar Veličković, University of Cambridge.
-- [New Down and Dirty Gameboy VRAM Timing Document + Test ROM](http://forums.nesdev.com/viewtopic.php?t=7861) by Kevtris.
+- [New Down and Dirty Gameboy VRAM Timing Document + Test ROM](https://forums.nesdev.org/viewtopic.php?p=79783) by Kevtris.
 - [Open Game Boy Documentation Project](https://mgba-emu.github.io/gbdoc/) - WIP documentation effort. Similar to Pan Docs but corrected and in a single page.
 - [Game Boy CPU Manual](http://marc.rawer.de/Gameboy/Docs/GBCPUman.pdf) - Assembly language commands, timings and opcodes. Has some inaccuracies and errors.
 - [GBDK tutorials in french](https://blog.flozz.fr/2018/10/01/developpement-gameboy-1-hello-world/)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You can find a (way cooler) web version of this list [here](https://gbdev.github
 
 - [Bootstrap ROM](https://tcrf.net/Game_Boy_Color_Bootstrap_ROM)
 - [Unused Palettes](https://tcrf.net/Notes:Game_Boy_Color_Bootstrap_ROM)
-- [Colorization palettes in the BIOS](https://forums.nesdev.com/viewtopic.php?p=114388&sid=c3d4ce08cfd9d9c834958d4f148750c3#p114388)
+- [Colorization palettes in the BIOS](https://forums.nesdev.org/viewtopic.php?p=114388#p114388)
 - [Boot ROM Disassembly](https://gist.github.com/drhelius/6063265)
 - [GBC Hicolour notes](https://romhack.github.io/doc/gbcHiColour/) - A technical note regarding Hicolour mode trick for Game Boy Color and its realization in the GBC game “Crystalis”.
 
@@ -324,8 +324,8 @@ Guides, tutorials and tools to develop software for Game Boy using the developme
 - [hardware.inc](https://github.com/tobiasvl/hardware.inc) - Standard include file containing Game Boy hardware definitions for use in RGBDS projects.
 - [Assembly tutorial by David Pello](https://gb-archive.github.io/salvage/tutorial_de_ensamblador/tutorial_de_ensamblador_la_decadence.html) - Good document to learn to produce working asm code for gb. Brief explanations of many important topics. Many examples with commented source code.
 - [assemblydigest](https://github.com/assemblydigest/gameboy) - Exploring Game Boy programming techniques:
-  - [Making an Empty Game Boy ROM (in Wiz)](http://assemblydigest.tumblr.com/post/77203696711/tutorial-making-an-empty-game-boy-rom-in-wiz)
-  - [Making Art for the Game Boy](http://assemblydigest.tumblr.com/post/77404621743/tutorial-making-art-for-the-game-boy)
+  - [Making an Empty Game Boy ROM (in Wiz)](https://assemblydigest.tumblr.com/post/77203696711/tutorial-making-an-empty-game-boy-rom-in-wiz)
+  - [Making Art for the Game Boy](https://assemblydigest.tumblr.com/post/77404621743/tutorial-making-art-for-the-game-boy)
 - [Beginner's Guide to Reverse Engineering GB](http://web.archive.org/web/20150511145100/http://www.bennvenn.com/Beginners_Guide_To_Reverse_Engineering.htm) - Some starting tips on disassembling and reverse engineering.
 - [FlappyBoy: Making a simple Game Boy Game](http://voidptr.io/blog/2017/01/21/GameBoy.html)
 - [Super Game Boy development](https://imanoleasgames.blogspot.no/2016/12/games-aside-1-super-game-boy.html) - Step by step tutorial to implement Super Game Boy features (frame and palettes).
@@ -572,7 +572,7 @@ Methods to improve and/or manipulate the camera's quality and behavior:
 - [GBCamcorder](https://github.com/furrtek/GBCamcorder) - Lo-Fi portable video recorder using a GameBoy Camera cartridge.
 - [GBCartRead](https://github.com/insidegadgets/GBCartRead) - Read ROM, Read RAM or Write RAM from/to a GameBoy Cartridge.
 - [GBxCart-RW](https://github.com/insidegadgets/GBxCart-RW) - A device for reading game ROMs, save games and restoring saves for GB, GBC and GBA carts from your PC via USB.
-- [Dumping the Super Game Boy Boot ROM](http://www.its.caltech.edu/~costis/sgb_hack/)
+- [Dumping the Super Game Boy Boot ROM](https://www.its.caltech.edu/~costis/sgb_hack/)
 - [sm83-render](https://github.com/msinger/sm83-render) - A 3D model of the Game Boy CPU layout in Blender.
 - [visual-sm83](https://iceboy.a-singer.de/visual6502/expert-sm83.html) - A visual transistor level simulation of the Game Boy CPU core in JavaScript, running in a browser.
 


### PR DESCRIPTION
- The NESDev forums moved from forums.nesdev.com to forums.nesdev.org, and changed some internal IDs. (So e.g. https://web.archive.org/web/20140928143126/http://forums.nesdev.com/viewtopic.php?t=7861 is now located at https://forums.nesdev.org/viewtopic.php?p=79783.)
- contributor-covenant.org changed their link structure.
- Some sites like tumblr.com and its.caltech.edu are accessible via HTTPS.
- tcrf.net doesn't allow any bots to check its links, as noted in https://github.com/gbdev/pandocs/pull/617.

Some links are still failing, but they should all be valid:

```
[MORE.md]
- Failed (403): https://forums.nesdev.org/viewtopic.php?p=79783

[README.md]
- Failed (403): https://forums.nesdev.org/viewtopic.php?p=114388#p114388
- Failed (403): https://assemblydigest.tumblr.com/post/77203696711/tutorial-making-an-empty-game-boy-rom-in-wiz
- Failed (403): https://assemblydigest.tumblr.com/post/77404621743/tutorial-making-art-for-the-game-boy
- Failed (403): https://old.reddit.com/r/EmuDev/comments/59pawp/gb_mode3_sprite_timing/
```